### PR TITLE
Update README-mkinitcpio.md

### DIFF
--- a/README-mkinitcpio.md
+++ b/README-mkinitcpio.md
@@ -97,7 +97,7 @@ automatically on every boot:
 
 ### mkinitcpio hook `ykfde`
 
-Last add `ykfde` to your hook list in `/etc/mkinitcpio.conf` and rebuild
+Last add `ykfde` (as well as `systemd` and change from `encrypt` to `sd-encrypt` if you have not already) to your hook list in `/etc/mkinitcpio.conf` and rebuild
 your initramfs with:
 
 > mkinitcpio -p linux


### PR DESCRIPTION
I just spent several hours trying to get ykfde to work on my reinstalled system. The README does not emphasize that systemd should be running in initramfs, only that it should be running. Hindsight is 20/20 though.

I love the updates from January.