### PR TITLE
Update module-setup.sh

### DIFF
--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -17,6 +17,10 @@ install() {
 	inst_simple /usr/lib/ykfde/worker
 	inst_simple /etc/ykfde.conf
 	inst_simple /usr/lib/systemd/system/ykfde-worker.service
+	inst_libdir_file libiniparser.so.1
+        inst_libdir_file libykpers-1.so.1
+        inst_libdir_file libyubikey.so.0
+	inst_libdir_file libkeyutils.so.1
 	ln_r $systemdsystemunitdir/ykfde-worker.service $systemdsystemunitdir/sysinit.target.wants/ykfde-worker.service
 
 	# this is required for second factor


### PR DESCRIPTION
Added missing libraries required during boot by /usr/lib/ykfde/worker:
 0x0000000000000001 (NEEDED)             Shared library: [libiniparser.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libkeyutils.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libykpers-1.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libyubikey.so.0]

Without these libraries, solution will not work on Fedora 33.