### PR TITLE
Update README-mkinitcpio.md to include information about UKIs

### DIFF
--- a/README-mkinitcpio.md
+++ b/README-mkinitcpio.md
@@ -153,3 +153,10 @@ options root=... rw quiet
 ```
 
 Reboot and have fun!
+
+If you use a [UKI](https://wiki.archlinux.org/title/Unified_kernel_image) you will need to add the img to your UKI build process. For systemd-ukify you should specify the challenges img in `/etc/kernel/uki.conf` like this:
+
+```
+[UKI]
+Initrd=/boot/initramfs-linux.img /boot/ykfde-challenges.img
+```


### PR DESCRIPTION
Adds information about adding the img to a UKI, with some instructions for systemd-ukify.

I discovered this issue: https://github.com/eworm-de/mkinitcpio-ykfde/issues/41 which pointed me in the right direction, and I eventually worked it out. I figured I could save someone else the half hour I spent working this out.